### PR TITLE
Change player's background color

### DIFF
--- a/focus.js
+++ b/focus.js
@@ -5,9 +5,11 @@ $ = (queryString) => document.querySelector(queryString);
 function focus(){
 	if($(".html5-video-container").style.position == 'fixed'){
 		$(".html5-video-container").style.position = 'relative';
+		$(".html5-video-player").style.setProperty("background-color", "black");
 	}
 	else{
 		$(".html5-video-container").style.position = 'fixed';
+		$(".html5-video-player").style.setProperty("background-color", "white");
 	}
 	
 }


### PR DESCRIPTION
When toggling the extension, the area where the video player used be is replaced by a large black box. This PR makes it so that this black box is changed to a white box, which blends in with Youtube's background and looks a lot cleaner than the current behavior.

For reference, the black box can be seen at the start of this gif.

![gif](https://camo.githubusercontent.com/cc23110889a75a438f6e7654aa5aabd8a2470178/68747470733a2f2f692e696d6775722e636f6d2f4856496e777a5a2e676966)