### PR TITLE
Add toggling feature

### DIFF
--- a/focus.js
+++ b/focus.js
@@ -1,18 +1,47 @@
 $ = (queryString) => document.querySelector(queryString);
 
-function focus(){
-	if($(".html5-video-container").style.position == 'fixed'){
-		$(".html5-video-container").style.position = 'relative';
-        $("video").style.width = "854px";
-        $("video").style.height = "480px";
-		$(".html5-video-player").style.setProperty("background-color", "black");
-	}
-	else{
-		$(".html5-video-container").style.position = 'fixed';
-        $("video").style.width = "426px";
-        $("video").style.height = "240px";
-		$(".html5-video-player").style.setProperty("background-color", "white");
-	}
+refresh();
+
+function refresh() {
+    browser.storage.local.get("focustube")
+        .then(function (settings) {
+            console.debug('existing: ' + JSON.stringify(settings));
+            if (settings.focustube.focus) {
+                focus();
+            } else {
+                reset();
+            }
+        }, function (error) {
+            console.debug('error: ' + JSON.stringify(error));
+        });
 }
 
-focus();
+function focus() {
+    // fix player itself
+    const playerElem = $('.html5-video-player');
+    playerElem.style.position = 'fixed';
+    playerElem.style.height = '52vh'; // 3:2
+    playerElem.style.width = '78vh';
+    playerElem.style.left = '15px';
+    playerElem.style.top = '75px';
+    playerElem.style.zIndex = '999';
+    // update background also
+    const playerContainerElem = $('#player-container-outer');
+    playerContainerElem.style.height = playerElem.style.height;
+    playerContainerElem.style.width = playerElem.style.width;
+    playerContainerElem.style.setProperty('background-color', 'black');
+}
+
+function reset() {
+    const playerElem = $('.html5-video-player');
+    playerElem.style.position = 'relative';
+    playerElem.style.height = '100%';
+    playerElem.style.width = '100%';
+    playerElem.style.left = '0px';
+    playerElem.style.top = '0px';
+    playerElem.style.zIndex = 'auto';
+    const playerContainerElem = $('#player-container-outer');
+    playerContainerElem.style.height = playerElem.style.height;
+    playerContainerElem.style.width = playerElem.style.width;
+    playerContainerElem.style.setProperty('background-color', 'white');
+}

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@
 browser.browserAction.onClicked.addListener(function () {
     browser.storage.local.get("focustube")
         .then(function (oldSettings) { // if has existing settings in storage
-            let newSettings = { focus: !(oldSettings.focustube.focus) }; // just toggle the value
+            const newSettings = { focus: !(oldSettings.focustube.focus) }; // just toggle the value
             save(newSettings);
         }, function (error) {
-            var newSettings = { focus: true }; // initial is true
+            const newSettings = { focus: true }; // initial is true
             save(newSettings);
         });
 });

--- a/index.js
+++ b/index.js
@@ -2,11 +2,15 @@
 browser.browserAction.onClicked.addListener(function () {
     browser.storage.local.get("focustube")
         .then(function (oldSettings) { // if has existing settings in storage
-            const newSettings = { focus: !(oldSettings.focustube.focus) }; // just toggle the value
+            let newSettings;
+            if(oldSettings && oldSettings.focustube) {
+                newSettings = { focus: !(oldSettings.focustube.focus) }; // just toggle the value
+            } else {
+                newSettings = { focus: true }; // initial is true
+            }
             save(newSettings);
         }, function (error) {
-            const newSettings = { focus: true }; // initial is true
-            save(newSettings);
+            console.debug('error: ' + JSON.stringify(error));
         });
 });
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,18 @@
-browser.browserAction.onClicked.addListener(function(){
-	browser.tabs.executeScript(null, {
-	  file: "focus.js"
-	});
+// when focustube is clicked
+browser.browserAction.onClicked.addListener(function () {
+    browser.storage.local.get("focustube")
+        .then(function (oldSettings) { // if has existing settings in storage
+            let newSettings = { focus: !(oldSettings.focustube.focus) }; // just toggle the value
+            save(newSettings);
+        }, function (error) {
+            var newSettings = { focus: true }; // initial is true
+            save(newSettings);
+        });
 });
+
+function save(newSettings) {
+    console.debug('Saving new settings: ' + JSON.stringify(newSettings));
+    browser.storage.local.set({ focustube: newSettings }).then(function (value) {
+        browser.tabs.executeScript(null, { file: "focus.js" }); // refresh tabs
+    });
+}

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,9 @@
 
   "permissions": [
     "activeTab",
-    "tabs"
+    "tabs",
+    "storage",
+    "*://*.youtube.com/*"
   ],
 
   "browser_action": {
@@ -20,8 +22,15 @@
     "default_title": "FocusTube"
   },
 
-  "background":
+  "background": {
+    "scripts": ["index.js"]
+  },
+
+  "content_scripts": [
     {
-      "scripts": ["index.js"]
+      "matches": ["*://*.youtube.com/*"],
+      "js": ["focus.js"],
+      "run_at": "document_end"
     }
+  ]
 }


### PR DESCRIPTION
This PR adds toggling functionality via [local browser storage](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/local).  
When user clicks the extension's button, it will toggle focus on/off.  
That will automatically update relevant tabs.

Also, I changed the width/height to be relative to the viewport (~current browser size), at 3:2 ratio.  
That leaves some room for other content like comments section.